### PR TITLE
fix: setValue void must not return a value

### DIFF
--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -87,7 +87,7 @@ abstract class Entity implements
             }
         }
 
-        return $this->setAttributeValue($name, $value);
+        $this->setAttributeValue($name, $value);
     }
 
     /** @return mixed */


### PR DESCRIPTION
A void function must not return a value