### PR TITLE
Keep functions, namespaced to avoid conflicts with WordPress Core

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -28,145 +28,144 @@ namespace OWC\ZGW {
     {
         return apiClientManager()->getClient($name);
     }
-}
 
-namespace {
-    if (! function_exists('add_query_arg')) {
-        function add_query_arg(...$args)
-        {
-            if (is_array($args[0])) {
-                if (count($args) < 2 || false === $args[1]) {
-                    $uri = $_SERVER['REQUEST_URI'];
-                } else {
-                    $uri = $args[1];
-                }
+    /**
+     * Taken from WordPress core. Thank you Matt.
+     */
+    function add_query_arg(...$args)
+    {
+        if (is_array($args[0])) {
+            if (count($args) < 2 || false === $args[1]) {
+                $uri = $_SERVER['REQUEST_URI'];
             } else {
-                if (count($args) < 3 || false === $args[2]) {
-                    $uri = $_SERVER['REQUEST_URI'];
-                } else {
-                    $uri = $args[2];
-                }
+                $uri = $args[1];
             }
-
-            $frag = strstr($uri, '#');
-            if ($frag) {
-                $uri = substr($uri, 0, -strlen($frag));
+        } else {
+            if (count($args) < 3 || false === $args[2]) {
+                $uri = $_SERVER['REQUEST_URI'];
             } else {
-                $frag = '';
+                $uri = $args[2];
             }
-
-            if (0 === stripos($uri, 'http://')) {
-                $protocol = 'http://';
-                $uri      = substr($uri, 7);
-            } elseif (0 === stripos($uri, 'https://')) {
-                $protocol = 'https://';
-                $uri      = substr($uri, 8);
-            } else {
-                $protocol = '';
-            }
-
-            if (str_contains($uri, '?')) {
-                list( $base, $query ) = explode('?', $uri, 2);
-                $base                .= '?';
-            } elseif ($protocol || ! str_contains($uri, '=')) {
-                $base  = $uri . '?';
-                $query = '';
-            } else {
-                $base  = '';
-                $query = $uri;
-            }
-
-            // wp_parse_str($query, $qs);
-            parse_str((string) $query, $qs);
-            $qs = urlencode_deep($qs); // This re-URL-encodes things that were already in the query string.
-            if (is_array($args[0])) {
-                foreach ($args[0] as $k => $v) {
-                    $qs[ $k ] = $v;
-                }
-            } else {
-                $qs[ $args[0] ] = $args[1];
-            }
-
-            foreach ($qs as $k => $v) {
-                if (false === $v) {
-                    unset($qs[ $k ]);
-                }
-            }
-
-            $ret = build_query($qs);
-            $ret = trim($ret, '?');
-            $ret = preg_replace('#=(&|$)#', '$1', $ret);
-            $ret = $protocol . $base . $ret . $frag;
-            $ret = rtrim($ret, '?');
-            $ret = str_replace('?#', '#', $ret);
-            return $ret;
         }
 
-        function urlencode_deep($value)
-        {
-            return map_deep($value, 'urlencode');
+        $frag = strstr($uri, '#');
+        if ($frag) {
+            $uri = substr($uri, 0, -strlen($frag));
+        } else {
+            $frag = '';
         }
 
-        function map_deep($value, $callback)
-        {
-            if (is_array($value)) {
-                foreach ($value as $index => $item) {
-                    $value[ $index ] = map_deep($item, $callback);
-                }
-            } elseif (is_object($value)) {
-                $object_vars = get_object_vars($value);
-                foreach ($object_vars as $property_name => $property_value) {
-                    $value->$property_name = map_deep($property_value, $callback);
-                }
+        if (0 === stripos($uri, 'http://')) {
+            $protocol = 'http://';
+            $uri      = substr($uri, 7);
+        } elseif (0 === stripos($uri, 'https://')) {
+            $protocol = 'https://';
+            $uri      = substr($uri, 8);
+        } else {
+            $protocol = '';
+        }
+
+        if (str_contains($uri, '?')) {
+            list( $base, $query ) = explode('?', $uri, 2);
+            $base                .= '?';
+        } elseif ($protocol || ! str_contains($uri, '=')) {
+            $base  = $uri . '?';
+            $query = '';
+        } else {
+            $base  = '';
+            $query = $uri;
+        }
+
+        // wp_parse_str($query, $qs);
+        parse_str((string) $query, $qs);
+        $qs = urlencode_deep($qs); // This re-URL-encodes things that were already in the query string.
+        if (is_array($args[0])) {
+            foreach ($args[0] as $k => $v) {
+                $qs[ $k ] = $v;
+            }
+        } else {
+            $qs[ $args[0] ] = $args[1];
+        }
+
+        foreach ($qs as $k => $v) {
+            if (false === $v) {
+                unset($qs[ $k ]);
+            }
+        }
+
+        $ret = build_query($qs);
+        $ret = trim($ret, '?');
+        $ret = preg_replace('#=(&|$)#', '$1', $ret);
+        $ret = $protocol . $base . $ret . $frag;
+        $ret = rtrim($ret, '?');
+        $ret = str_replace('?#', '#', $ret);
+        return $ret;
+    }
+
+    function urlencode_deep($value)
+    {
+        return map_deep($value, 'urlencode');
+    }
+
+    function map_deep($value, $callback)
+    {
+        if (is_array($value)) {
+            foreach ($value as $index => $item) {
+                $value[ $index ] = map_deep($item, $callback);
+            }
+        } elseif (is_object($value)) {
+            $object_vars = get_object_vars($value);
+            foreach ($object_vars as $property_name => $property_value) {
+                $value->$property_name = map_deep($property_value, $callback);
+            }
+        } else {
+            $value = call_user_func($callback, $value);
+        }
+
+        return $value;
+    }
+
+    function build_query($data)
+    {
+        return _http_build_query($data, null, '&', '', false);
+    }
+
+    function _http_build_query($data, $prefix = null, $sep = null, $key = '', $urlencode = true)
+    {
+        $ret = array();
+
+        foreach ((array) $data as $k => $v) {
+            if ($urlencode) {
+                $k = urlencode($k);
+            }
+
+            if (is_int($k) && null !== $prefix) {
+                $k = $prefix . $k;
+            }
+
+            if (! empty($key)) {
+                $k = $key . '%5B' . $k . '%5D';
+            }
+
+            if (null === $v) {
+                continue;
+            } elseif (false === $v) {
+                $v = '0';
+            }
+
+            if (is_array($v) || is_object($v)) {
+                array_push($ret, _http_build_query($v, '', $sep, $k, $urlencode));
+            } elseif ($urlencode) {
+                array_push($ret, $k . '=' . urlencode($v));
             } else {
-                $value = call_user_func($callback, $value);
+                array_push($ret, $k . '=' . $v);
             }
-
-            return $value;
         }
 
-        function build_query($data)
-        {
-            return _http_build_query($data, null, '&', '', false);
+        if (null === $sep) {
+            $sep = ini_get('arg_separator.output');
         }
 
-        function _http_build_query($data, $prefix = null, $sep = null, $key = '', $urlencode = true)
-        {
-            $ret = array();
-
-            foreach ((array) $data as $k => $v) {
-                if ($urlencode) {
-                    $k = urlencode($k);
-                }
-
-                if (is_int($k) && null !== $prefix) {
-                    $k = $prefix . $k;
-                }
-
-                if (! empty($key)) {
-                    $k = $key . '%5B' . $k . '%5D';
-                }
-
-                if (null === $v) {
-                    continue;
-                } elseif (false === $v) {
-                    $v = '0';
-                }
-
-                if (is_array($v) || is_object($v)) {
-                    array_push($ret, _http_build_query($v, '', $sep, $k, $urlencode));
-                } elseif ($urlencode) {
-                    array_push($ret, $k . '=' . urlencode($v));
-                } else {
-                    array_push($ret, $k . '=' . $v);
-                }
-            }
-
-            if (null === $sep) {
-                $sep = ini_get('arg_separator.output');
-            }
-
-            return implode($sep, $ret);
-        }
+        return implode($sep, $ret);
     }
 }

--- a/src/Endpoints/Endpoint.php
+++ b/src/Endpoints/Endpoint.php
@@ -66,7 +66,7 @@ abstract class Endpoint
         );
 
         if ($filter) {
-            $uri = \add_query_arg($filter->getParameters(), $uri);
+            $uri = \OWC\ZGW\add_query_arg($filter->getParameters(), $uri);
         }
 
         return $uri;
@@ -77,7 +77,7 @@ abstract class Endpoint
         $uri = $this->buildUri($uri, $filter);
 
         if ($this->endpointSupportsExpand() && $this->expandIsEnabled()) {
-            $uri = add_query_arg([
+            $uri = \OWC\ZGW\add_query_arg([
                 'expand' => implode(',', $this->getExpandableResources())
             ], $uri);
         }


### PR DESCRIPTION
Keep all WP functions, for they are useful
But namespaced them in the existing namesopace.

Reason;

When installing the package in a "WordPress with Composer" project, the helpers file is loaded on bootstrap, before WordPress, thus the "function_exists" check doesn't work.

When installing the plugin stand-alone, after running composer install, this is not an issue, because WordPress loads before plugins.

This PR fixes the problem, keeps the functions.

The change seems large, all I did was;

- remove the `namespace {` line, and the `}` above it to move the functions into the namespace
- remove the function exists check, rebalance whitespace in the file.
- use the add_query_arg function namespaced, 2 instances in 1 file.