### PR TITLE
fix: use default jwt authenticator for xxllnc

### DIFF
--- a/src/Clients/Xxllnc/Authenticator.php
+++ b/src/Clients/Xxllnc/Authenticator.php
@@ -8,13 +8,4 @@ use OWC\ZGW\Contracts\AbstractTokenAuthenticator;
 
 class Authenticator extends AbstractTokenAuthenticator
 {
-    public function getAuthString(): string
-    {
-        return $this->generateToken();
-    }
-
-    public function generateToken(): string
-    {
-        return $this->credentials->getClientSecret();
-    }
 }


### PR DESCRIPTION
In onze testomgeving werkte de XXLLNC authenticatie niet omdat dit geen JWT token was - is er een specifieke reden om deze versimpelde variant te hebben?