### PR TITLE
feat: configure supplier SSL cert for mTLS

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -28,7 +28,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$tokenHttpClient->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -52,7 +53,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$tokenHttpClient->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -77,7 +79,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -101,7 +104,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -125,7 +129,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -149,7 +154,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 
@@ -173,7 +179,8 @@ return [
 		if ($credentials->hasCertificates()) {
 			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
-				$credentials->getPrivateCertificate()
+				$credentials->getPrivateCertificate(),
+				$credentials->getSupplierCertificate()
 			));
 		}
 

--- a/src/ApiCredentials.php
+++ b/src/ApiCredentials.php
@@ -10,6 +10,7 @@ class ApiCredentials
 
     protected string $publicCertificate;
     protected string $privateCertificate;
+    protected string $supplierCertificate;
 
     public function getClientId(): string
     {
@@ -39,6 +40,11 @@ class ApiCredentials
     public function getPrivateCertificate(): string
     {
         return $this->privateCertificate;
+    }
+
+    public function getSupplierCertificate(): string
+    {
+        return $this->supplierCertificate;
     }
 
     public function setClientId(string $clientId): self
@@ -72,6 +78,13 @@ class ApiCredentials
     public function setPrivateCertificate(string $path): self
     {
         $this->privateCertificate = $path;
+
+        return $this;
+    }
+
+    public function setSupplierCertificate(string $path): self
+    {
+        $this->supplierCertificate = $path;
 
         return $this;
     }

--- a/src/Http/SslCertificatesStore.php
+++ b/src/Http/SslCertificatesStore.php
@@ -8,7 +8,8 @@ class SslCertificatesStore
 {
     public function __construct(
         protected string $publicKeyPath,
-        protected string $privateKeyPath
+        protected string $privateKeyPath,
+		protected string $supplierCertificatePath
     ) {
     }
 
@@ -21,6 +22,11 @@ class SslCertificatesStore
     {
         return $this->privateKeyPath;
     }
+
+	public function getSupplierCertificatePath(): string
+	{
+		return $this->supplierCertificatePath;
+	}
 
     public function isEmpty(): bool
     {

--- a/src/Http/WordPress/WordPressRequestClient.php
+++ b/src/Http/WordPress/WordPressRequestClient.php
@@ -61,19 +61,67 @@ class WordPressRequestClient implements RequestClientInterface
         return $this;
     }
 
-    public function addSslCertificates(SslCertificatesStore $store): self
-    {
-        if ($store->isIncomplete()) {
-            throw new InvalidArgumentException('Missing SSL certificates: both public and private certificates are required for WordPressRequestClient configuration.');
-        }
+	public function addSslCertificates(SslCertificatesStore $store): self
+	{
+		if ($store->isIncomplete()) {
+			throw new InvalidArgumentException(
+				'Missing SSL certificates: both public and private certificates are required for WordPressRequestClient configuration.'
+			);
+		}
 
-        add_action('http_api_curl', function ($handle) use ($store) {
-            curl_setopt($handle, CURLOPT_SSLCERT, $store->getPublicCertificatePath());
-            curl_setopt($handle, CURLOPT_SSLKEY, $store->getPrivateCertificatePath());
-        });
+		add_filter('http_request_args', $this->getHttpRequestArgsSslCertificatesCallback($store), 10, 1);
+		add_action('http_api_curl', $this->getHttpApiCurlSslCertificatesCallback($store), 10, 2);
 
-        return $this;
-    }
+		return $this;
+	}
+
+	/**
+	 * Configure the WordPress HTTP API trust store for supplier certificate validation.
+	 */
+	protected function getHttpRequestArgsSslCertificatesCallback(SslCertificatesStore $store): \Closure
+	{
+		return function (array $parsedArgs) use ($store): array {
+			// Validate that the request is initiated by this package.
+			if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+				return $parsedArgs;
+			}
+
+			$supplierCertificatePath = $store->getSupplierCertificatePath();
+
+			if ('' === trim($supplierCertificatePath)) {
+				return $parsedArgs;
+			}
+
+			$parsedArgs['sslverify']       = true;
+			$parsedArgs['sslcertificates'] = $supplierCertificatePath;
+
+			return $parsedArgs;
+		};
+	}
+
+	/**
+	 * Configure the cURL client certificate and private key for mTLS authentication.
+	 */
+	protected function getHttpApiCurlSslCertificatesCallback(SslCertificatesStore $store): \Closure
+	{
+		return function ($handle, $parsedArgs) use ($store): void {
+			// Validate that the request is initiated by this package.
+			if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+				return;
+			}
+
+			curl_setopt($handle, CURLOPT_SSLCERT, $store->getPublicCertificatePath());
+			curl_setopt($handle, CURLOPT_SSLKEY, $store->getPrivateCertificatePath());
+
+			$supplierCertificatePath = $store->getSupplierCertificatePath();
+
+			if ('' === trim($supplierCertificatePath)) {
+				return;
+			}
+
+			curl_setopt($handle, CURLOPT_CAINFO, $supplierCertificatePath);
+		};
+	}
 
     /**
      * @param \WP_Error|array<mixed> $response

--- a/src/WordPress/ClientProvider.php
+++ b/src/WordPress/ClientProvider.php
@@ -96,6 +96,7 @@ class ClientProvider extends ServiceProvider
 
         $credentials->setPublicCertificate($config['client_ssl_public_cert_file']);
         $credentials->setPrivateCertificate($config['client_ssl_private_cert_file']);
+		$credentials->setSupplierCertificate($config['client_ssl_supplier_cert_file'] ?? '');
 
         return $credentials;
     }

--- a/src/WordPress/SettingsProvider.php
+++ b/src/WordPress/SettingsProvider.php
@@ -195,6 +195,33 @@ class SettingsProvider extends ServiceProvider
             }
         ]);
 
+		// Is only visible when 'client_ssl_verify_enabled' is checked.
+		$options->add_group_field($clients, [
+			'name' => 'SSL leverancier certificaat (.cer/.crt)',
+			'desc' => 'Voer het pad in naar het SSL certificaat bestand van de leverancier',
+			'id' => 'client_ssl_supplier_cert_file',
+			'type' => 'text',
+			'sanitization_cb' => function ($value, $fieldProps, \CMB2_Field $field) {
+				if (empty($value)) {
+					return '';
+				}
+
+				if ($this->fileIsReadable($value) === false) {
+					$this->generateFieldError($field, 'Het ingevoerde pad naar het SSL certificaat van de leverancier is ongeldig.');
+
+					return '';
+				}
+
+				if ($this->isValidCertificate($value) === false) {
+					$this->generateFieldError($field, 'Het ingevoerde SSL certificaat van de leverancier is niet leesbaar of het is geen geldig certificaat bestand.');
+
+					return '';
+				}
+
+				return realpath($value);
+			}
+		]);
+
         add_action('admin_notices', $this->queueAdminNotices(...));
     }
 


### PR DESCRIPTION
Steeds meer leveranciers vereisen een volledige mTLS.
Om dit te bewerkstelligen moet het certificaat van de leverancier vertrouwd worden en toegevoegd worden aan de Curl argumenten. Als er geen certificaat van de leverancier is ingesteld wordt daar ook niets mee gedaan. Deze toevoeging zal bestaande configuraties niet breken.