### PR TITLE
refactor: make InformationObject final status check optional

### DIFF
--- a/src/ApiCredentials.php
+++ b/src/ApiCredentials.php
@@ -92,12 +92,12 @@ class ApiCredentials
     public function __debugInfo(): array
     {
         return [
-            'clientId'              => '',
-            'clientSecret'          => '',
-            'clientTokenEndpoint'   => '',
-            'publicCertificate'     => '',
-            'privateCertificate'    => '',
-            'supplierCertificate'   => '',
+            'clientId' => '',
+            'clientSecret' => '',
+            'clientTokenEndpoint' => '',
+            'publicCertificate' => '',
+            'privateCertificate' => '',
+            'supplierCertificate' => '',
         ];
     }
 }

--- a/src/Clients/DecosJoin/Client.php
+++ b/src/Clients/DecosJoin/Client.php
@@ -45,7 +45,7 @@ class Client extends AbstractClient
         'zaken' => [ZakenEndpoint::class, 'zaken'],
         'statussen' => [StatussenEndpoint::class, 'zaken'],
         'rollen' => [RollenEndpoint::class, 'zaken'],
-		'resultaten' => [ResultatenEndpoint::class, 'zaken'],
+        'resultaten' => [ResultatenEndpoint::class, 'zaken'],
         'zaakeigenschappen' => [ZaakeigenschappenEndpoint::class, 'zaken'],
         'zaakinformatieobjecten' => [ZaakinformatieobjectenEndpoint::class, 'zaken'],
 

--- a/src/Endpoints/ZaakobjectenEndpoint.php
+++ b/src/Endpoints/ZaakobjectenEndpoint.php
@@ -43,14 +43,14 @@ class ZaakobjectenEndpoint extends Endpoint
         return $this->getPagedCollection($this->handleResponse($response));
     }
 
-	public function create(Zaakobject $model): Zaakobject
-	{
-		$response = $this->httpClient->post(
-			$this->buildUri($this->endpoint),
-			$model->toJson(),
-			$this->buildRequestOptions()
-		);
+    public function create(Zaakobject $model): Zaakobject
+    {
+        $response = $this->httpClient->post(
+            $this->buildUri($this->endpoint),
+            $model->toJson(),
+            $this->buildRequestOptions()
+        );
 
-		return $this->getSingleEntity($this->handleResponse($response));
-	}
+        return $this->getSingleEntity($this->handleResponse($response));
+    }
 }

--- a/src/Entities/Casts/Related/Zaakinformatieobjecten.php
+++ b/src/Entities/Casts/Related/Zaakinformatieobjecten.php
@@ -17,7 +17,7 @@ class Zaakinformatieobjecten extends ResourceCollection
     public function resolveRelatedResourceCollection(Entity $entity): Collection
     {
         if (! $entity instanceof Zaak) {
-            throw new InvalidArgumentException("A Zaak entity is required to resolve Rollen");
+            throw new InvalidArgumentException('A Zaak entity is required to resolve Rollen');
         }
 
         $filter = new ZaakinformatieobjectenFilter();
@@ -28,8 +28,9 @@ class Zaakinformatieobjecten extends ResourceCollection
                 return false;
             }
 
+			// Only include objects that are not classified and have a final status (if status is available).
             return ! $object->informatieobject->vertrouwelijkheidaanduiding->isClassified()
-                && $object->informatieobject->status->hasFinalStatus();
+                && ($object->informatieobject?->status?->hasFinalStatus() ?? true);
         });
     }
 }

--- a/src/Http/SslCertificatesStore.php
+++ b/src/Http/SslCertificatesStore.php
@@ -9,7 +9,7 @@ class SslCertificatesStore
     public function __construct(
         protected string $publicKeyPath,
         protected string $privateKeyPath,
-		protected string $supplierCertificatePath
+        protected string $supplierCertificatePath
     ) {
     }
 
@@ -23,10 +23,10 @@ class SslCertificatesStore
         return $this->privateKeyPath;
     }
 
-	public function getSupplierCertificatePath(): string
-	{
-		return $this->supplierCertificatePath;
-	}
+    public function getSupplierCertificatePath(): string
+    {
+        return $this->supplierCertificatePath;
+    }
 
     public function isEmpty(): bool
     {

--- a/src/Http/WordPress/WordPressRequestClient.php
+++ b/src/Http/WordPress/WordPressRequestClient.php
@@ -61,67 +61,67 @@ class WordPressRequestClient implements RequestClientInterface
         return $this;
     }
 
-	public function addSslCertificates(SslCertificatesStore $store): self
-	{
-		if ($store->isIncomplete()) {
-			throw new InvalidArgumentException(
-				'Missing SSL certificates: both public and private certificates are required for WordPressRequestClient configuration.'
-			);
-		}
+    public function addSslCertificates(SslCertificatesStore $store): self
+    {
+        if ($store->isIncomplete()) {
+            throw new InvalidArgumentException(
+                'Missing SSL certificates: both public and private certificates are required for WordPressRequestClient configuration.'
+            );
+        }
 
-		add_filter('http_request_args', $this->getHttpRequestArgsSslCertificatesCallback($store), 10, 1);
-		add_action('http_api_curl', $this->getHttpApiCurlSslCertificatesCallback($store), 10, 2);
+        add_filter('http_request_args', $this->getHttpRequestArgsSslCertificatesCallback($store), 10, 1);
+        add_action('http_api_curl', $this->getHttpApiCurlSslCertificatesCallback($store), 10, 2);
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Configure the WordPress HTTP API trust store for supplier certificate validation.
-	 */
-	protected function getHttpRequestArgsSslCertificatesCallback(SslCertificatesStore $store): \Closure
-	{
-		return function (array $parsedArgs) use ($store): array {
-			// Validate that the request is initiated by this package.
-			if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
-				return $parsedArgs;
-			}
+    /**
+     * Configure the WordPress HTTP API trust store for supplier certificate validation.
+     */
+    protected function getHttpRequestArgsSslCertificatesCallback(SslCertificatesStore $store): \Closure
+    {
+        return function (array $parsedArgs) use ($store): array {
+            // Validate that the request is initiated by this package.
+            if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+                return $parsedArgs;
+            }
 
-			$supplierCertificatePath = $store->getSupplierCertificatePath();
+            $supplierCertificatePath = $store->getSupplierCertificatePath();
 
-			if ('' === trim($supplierCertificatePath)) {
-				return $parsedArgs;
-			}
+            if ('' === trim($supplierCertificatePath)) {
+                return $parsedArgs;
+            }
 
-			$parsedArgs['sslverify']       = true;
-			$parsedArgs['sslcertificates'] = $supplierCertificatePath;
+            $parsedArgs['sslverify'] = true;
+            $parsedArgs['sslcertificates'] = $supplierCertificatePath;
 
-			return $parsedArgs;
-		};
-	}
+            return $parsedArgs;
+        };
+    }
 
-	/**
-	 * Configure the cURL client certificate and private key for mTLS authentication.
-	 */
-	protected function getHttpApiCurlSslCertificatesCallback(SslCertificatesStore $store): \Closure
-	{
-		return function ($handle, $parsedArgs) use ($store): void {
-			// Validate that the request is initiated by this package.
-			if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
-				return;
-			}
+    /**
+     * Configure the cURL client certificate and private key for mTLS authentication.
+     */
+    protected function getHttpApiCurlSslCertificatesCallback(SslCertificatesStore $store): \Closure
+    {
+        return function ($handle, $parsedArgs) use ($store): void {
+            // Validate that the request is initiated by this package.
+            if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+                return;
+            }
 
-			curl_setopt($handle, CURLOPT_SSLCERT, $store->getPublicCertificatePath());
-			curl_setopt($handle, CURLOPT_SSLKEY, $store->getPrivateCertificatePath());
+            curl_setopt($handle, CURLOPT_SSLCERT, $store->getPublicCertificatePath());
+            curl_setopt($handle, CURLOPT_SSLKEY, $store->getPrivateCertificatePath());
 
-			$supplierCertificatePath = $store->getSupplierCertificatePath();
+            $supplierCertificatePath = $store->getSupplierCertificatePath();
 
-			if ('' === trim($supplierCertificatePath)) {
-				return;
-			}
+            if ('' === trim($supplierCertificatePath)) {
+                return;
+            }
 
-			curl_setopt($handle, CURLOPT_CAINFO, $supplierCertificatePath);
-		};
-	}
+            curl_setopt($handle, CURLOPT_CAINFO, $supplierCertificatePath);
+        };
+    }
 
     /**
      * @param \WP_Error|array<mixed> $response

--- a/src/WordPress/ClientProvider.php
+++ b/src/WordPress/ClientProvider.php
@@ -96,7 +96,7 @@ class ClientProvider extends ServiceProvider
 
         $credentials->setPublicCertificate($config['client_ssl_public_cert_file']);
         $credentials->setPrivateCertificate($config['client_ssl_private_cert_file']);
-		$credentials->setSupplierCertificate($config['client_ssl_supplier_cert_file'] ?? '');
+        $credentials->setSupplierCertificate($config['client_ssl_supplier_cert_file'] ?? '');
 
         return $credentials;
     }

--- a/src/WordPress/SettingsProvider.php
+++ b/src/WordPress/SettingsProvider.php
@@ -195,32 +195,32 @@ class SettingsProvider extends ServiceProvider
             }
         ]);
 
-		// Is only visible when 'client_ssl_verify_enabled' is checked.
-		$options->add_group_field($clients, [
-			'name' => 'SSL leverancier certificaat (.cer/.crt)',
-			'desc' => 'Voer het pad in naar het SSL certificaat bestand van de leverancier',
-			'id' => 'client_ssl_supplier_cert_file',
-			'type' => 'text',
-			'sanitization_cb' => function ($value, $fieldProps, \CMB2_Field $field) {
-				if (empty($value)) {
-					return '';
-				}
+        // Is only visible when 'client_ssl_verify_enabled' is checked.
+        $options->add_group_field($clients, [
+            'name' => 'SSL leverancier certificaat (.cer/.crt)',
+            'desc' => 'Voer het pad in naar het SSL certificaat bestand van de leverancier',
+            'id' => 'client_ssl_supplier_cert_file',
+            'type' => 'text',
+            'sanitization_cb' => function ($value, $fieldProps, \CMB2_Field $field) {
+                if (empty($value)) {
+                    return '';
+                }
 
-				if ($this->fileIsReadable($value) === false) {
-					$this->generateFieldError($field, 'Het ingevoerde pad naar het SSL certificaat van de leverancier is ongeldig.');
+                if ($this->fileIsReadable($value) === false) {
+                    $this->generateFieldError($field, 'Het ingevoerde pad naar het SSL certificaat van de leverancier is ongeldig.');
 
-					return '';
-				}
+                    return '';
+                }
 
-				if ($this->isValidCertificate($value) === false) {
-					$this->generateFieldError($field, 'Het ingevoerde SSL certificaat van de leverancier is niet leesbaar of het is geen geldig certificaat bestand.');
+                if ($this->isValidCertificate($value) === false) {
+                    $this->generateFieldError($field, 'Het ingevoerde SSL certificaat van de leverancier is niet leesbaar of het is geen geldig certificaat bestand.');
 
-					return '';
-				}
+                    return '';
+                }
 
-				return realpath($value);
-			}
-		]);
+                return realpath($value);
+            }
+        ]);
 
         add_action('admin_notices', $this->queueAdminNotices(...));
     }


### PR DESCRIPTION
Aangezien de status niet verplicht is en schijnbaar sommige gemeenten dus zonder een status werken, stel ik deze verandering voor. 

De linter maakt het ietwat onduidelijk maar het gaat om:
-- $object->informatieobject->status->hasFinalStatus();
++ ($object->informatieobject?->status?->hasFinalStatus() ?? true);

Te vinden op OWC\ZGW\Entities\Casts\Related\Zaakinformatieobjecten:33

[Link naar de documentatie](https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.7.0#tag/enkelvoudiginformatieobjecten/operation/enkelvoudiginformatieobject_retrieve)
<img width="905" height="412" alt="Screenshot 2026-06-11 at 17 52 02" src="https://github.com/user-attachments/assets/23a040b6-2d05-430f-828a-fa312c474bc1" />
