### PR TITLE
fix: registers with same supplier resolved to each other's client/certs

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -219,8 +219,11 @@ return [
     /**
      * HTTP clients
      */
+    // Every register needs its own transport instance: WordPressRequestClient::addSslCertificates()
+    // registers global WordPress hooks scoped to this instance, which would otherwise leak
+    // between registers if the same instance were shared.
     'http.client' => function (Container $container) {
-        return $container->get(Http\WordPress\WordPressRequestClient::class);
+        return $container->make(Http\WordPress\WordPressRequestClient::class);
     },
     Http\WordPress\WordPressRequestClient::class => function () {
         return new Http\WordPress\WordPressRequestClient(

--- a/src/ApiClientManager.php
+++ b/src/ApiClientManager.php
@@ -29,15 +29,26 @@ class ApiClientManager
     {
         $endpoints = $this->container->get('api.endpoints');
 
+        $matchedClientName = null;
+        $matchedEndpointLength = -1;
+
         foreach ($endpoints as $clientName => $urlCollection) {
             $endpoint = $urlCollection->get($registry);
 
-            if (strpos($url, $endpoint) === 0) {
-                return $this->getClient($clientName);
+            if (empty($endpoint) || strpos($url, $endpoint) !== 0) {
+                continue;
+            }
+
+            // Multiple registered clients can share the same host/prefix
+            // (e.g. two registers with the same supplier). Prefer the
+            // longest matching endpoint, since it is the most specific one.
+            if (strlen($endpoint) > $matchedEndpointLength) {
+                $matchedClientName = $clientName;
+                $matchedEndpointLength = strlen($endpoint);
             }
         }
 
-        return null;
+        return $matchedClientName ? $this->getClient($matchedClientName) : null;
     }
 
     public function addClient(

--- a/src/Entities/Casts/Lazy/AbstractResource.php
+++ b/src/Entities/Casts/Lazy/AbstractResource.php
@@ -12,7 +12,8 @@ use function OWC\ZGW\apiClientManager;
 
 abstract class AbstractResource extends AbstractCast
 {
-    protected string $registryType = 'registry';
+    use ResolvesClientFromUrl;
+
     protected string $resourceType = Entity::class;
 
     public function set(Entity $model, string $key, mixed $value): mixed
@@ -44,7 +45,9 @@ abstract class AbstractResource extends AbstractCast
         $client = $model->client();
 
         if ($this->isUrl($value)) {
-            $client = apiClientManager()->clientFromUrl($value, $this->registryType);
+            if (! $this->belongsToClient($value, $client)) {
+                $client = apiClientManager()->clientFromUrl($value, $this->registryType);
+            }
 
             $value = $this->getUuidFromUrl($value);
         }
@@ -79,15 +82,5 @@ abstract class AbstractResource extends AbstractCast
     protected function buildResource(array $itemData, Entity $model): Entity
     {
         return new $this->resourceType($itemData, $model->client());
-    }
-
-    protected function isUrl(string $value): bool
-    {
-        return (bool) filter_var($value, FILTER_VALIDATE_URL);
-    }
-
-    protected function getUuidFromUrl(string $url): string
-    {
-        return substr($url, strrpos($url, '/') + 1);
     }
 }

--- a/src/Entities/Casts/Lazy/ResolvesClientFromUrl.php
+++ b/src/Entities/Casts/Lazy/ResolvesClientFromUrl.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OWC\ZGW\Entities\Casts\Lazy;
+
+use OWC\ZGW\Contracts\Client;
+
+trait ResolvesClientFromUrl
+{
+    protected string $registryType = 'registry';
+
+    protected function isUrl(string $value): bool
+    {
+        return (bool) filter_var($value, FILTER_VALIDATE_URL);
+    }
+
+    /**
+     * A model's own client already targets the correct register, so it
+     * must be preferred over a global URL-based lookup, which cannot
+     * disambiguate between multiple registered clients of the same
+     * supplier (e.g. two registers sharing the same host).
+     */
+    protected function belongsToClient(string $url, ?Client $client): bool
+    {
+        if (! $client) {
+            return false;
+        }
+
+        $endpoint = $client->getEndpointUrlByType($this->registryType);
+
+        return ! empty($endpoint) && strpos($url, $endpoint) === 0;
+    }
+
+    protected function getUuidFromUrl(string $url): string
+    {
+        return substr($url, strrpos($url, '/') + 1);
+    }
+}

--- a/src/Entities/Casts/Lazy/ResourceCollection.php
+++ b/src/Entities/Casts/Lazy/ResourceCollection.php
@@ -14,7 +14,7 @@ use function OWC\ZGW\apiClientManager;
 
 abstract class ResourceCollection extends AbstractCast
 {
-    protected string $registryType = 'registry';
+    use ResolvesClientFromUrl;
 
     public function set(Entity $model, string $key, mixed $value): mixed
     {
@@ -56,7 +56,10 @@ abstract class ResourceCollection extends AbstractCast
             $client = $model->client();
 
             if ($this->isUrl($item)) {
-                $client = apiClientManager()->clientFromUrl($item, $this->registryType);
+                if (! $this->belongsToClient($item, $client)) {
+                    $client = apiClientManager()->clientFromUrl($item, $this->registryType);
+                }
+
                 $item = $this->getUuidFromUrl($item);
             }
 
@@ -94,14 +97,4 @@ abstract class ResourceCollection extends AbstractCast
     }
 
     abstract protected function resolveResource(Client $client, string $uuid): ?Entity;
-
-    protected function isUrl(string $value): bool
-    {
-        return (bool) filter_var($value, FILTER_VALIDATE_URL);
-    }
-
-    protected function getUuidFromUrl(string $url): string
-    {
-        return substr($url, strrpos($url, '/') + 1);
-    }
 }

--- a/src/Http/WordPress/WordPressRequestClient.php
+++ b/src/Http/WordPress/WordPressRequestClient.php
@@ -13,10 +13,12 @@ use OWC\ZGW\Http\RequestClientInterface;
 class WordPressRequestClient implements RequestClientInterface
 {
     protected RequestOptions $options;
+    protected string $instanceId;
 
     public function __construct(?RequestOptions $options = null)
     {
         $this->options = $options ?: new RequestOptions([]);
+        $this->instanceId = uniqid('owc_client_', true);
     }
 
     public function get(string $uri, ?RequestOptions $options = null): Response
@@ -81,8 +83,10 @@ class WordPressRequestClient implements RequestClientInterface
     protected function getHttpRequestArgsSslCertificatesCallback(SslCertificatesStore $store): \Closure
     {
         return function (array $parsedArgs) use ($store): array {
-            // Validate that the request is initiated by this package.
-            if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+            // Validate that the request is initiated by this specific client instance. WordPress
+            // hooks are global, so without this check certificates from another register (client
+            // instance) sharing the same "http_request_args" filter would leak into this request.
+            if (($parsedArgs['headers']['_owc_client_instance'] ?? null) !== $this->instanceId) {
                 return $parsedArgs;
             }
 
@@ -105,8 +109,10 @@ class WordPressRequestClient implements RequestClientInterface
     protected function getHttpApiCurlSslCertificatesCallback(SslCertificatesStore $store): \Closure
     {
         return function ($handle, $parsedArgs) use ($store): void {
-            // Validate that the request is initiated by this package.
-            if (! isset($parsedArgs['headers']['_owc_request_logging'])) {
+            // Validate that the request is initiated by this specific client instance. WordPress
+            // hooks are global, so without this check certificates from another register (client
+            // instance) sharing the same "http_api_curl" action would leak into this request.
+            if (($parsedArgs['headers']['_owc_client_instance'] ?? null) !== $this->instanceId) {
                 return;
             }
 
@@ -138,6 +144,7 @@ class WordPressRequestClient implements RequestClientInterface
     protected function mergeRequestOptions(?RequestOptions $options = null): RequestOptions
     {
         $this->options->addHeader('_owc_request_logging', microtime(true));
+        $this->options->addHeader('_owc_client_instance', $this->instanceId);
 
         if (! $options) {
             return $this->options;


### PR DESCRIPTION
 Het komt schijnbaar voor dat een gemeente bij 1 ZGW leverancier 2 koppelingen heeft lopen (bijvoorbeeld twee registers die beide via dezelfde leverancier lopen). Door lokaal te testen kwam ik erachter dat de eerste match werd gebruikt voor het 'builden' van een register met de client/certificaten van de andere koppeling, omdat beide koppelingen dezelfde host/endpoint-prefix delen.

**Oorzaken**

1. ApiClientManager::clientFromUrl() doorloopt alle geregistreerde clients en retourneert de éérste waarvan de endpoint-prefix matcht. Als twee registers dezelfde leverancier (en dus grotendeels dezelfde URL) hebben, kan de verkeerde client geretourneerd worden. Dit is nu aangepast naar de langste (meest specifieke) match.

2. WordPressRequestClient werd als singleton uit de container gehaald (`->get()`), terwijl de SSL-certificaten worden geregeld via globale WordPress hooks (http_request_args, http_api_curl). Omdat die hooks scoped waren op "is dit een request van dit package" in plaats van "is dit een request van déze clientinstantie", konden certificaten van het ene register gebruikt worden voor requests van het andere. Elke client krijgt nu een eigen instantie (`->make()`) met een uniek instanceId, en de hooks checken op dat ID.
3. De lazy-resolving casts (AbstractResource/ResourceCollection) haalden bij het volgen van een resource-URL altijd opnieuw een client op via clientFromUrl(), ook als het model al het juiste client had. Bij gedeelde hosts leidde dat tot dezelfde verkeerde-match-problematiek. Nu wordt eerst gecontroleerd of het bestaande client van het model al bij de URL hoort (belongsToClient()), en alleen als dat niet zo is wordt er een nieuwe lookup gedaan.

Bovenstaande wordt opgelost door deze PR.