### PR TITLE
fix: ssl certificates not applied consistently to Mozart and OpenWave…

### DIFF
--- a/config/container.php
+++ b/config/container.php
@@ -23,10 +23,10 @@ return [
         ApiCredentials $credentials,
         ApiUrlCollection $endpoints
     ) {
-		$tokenHttpClient = clone $container->make('http.client');
+		$client = $container->make('http.client');
 
 		if ($credentials->hasCertificates()) {
-			$tokenHttpClient->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
+			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
 				$credentials->getPrivateCertificate(),
 				$credentials->getSupplierCertificate()
@@ -34,8 +34,8 @@ return [
 		}
 
         return new Clients\Mozart\Client(
-            $container->make('http.client'),
-            $container->make(Clients\Mozart\Authenticator::class, ['credentials' => $credentials, 'client' => $tokenHttpClient]),
+            $client,
+            $container->make(Clients\Mozart\Authenticator::class, ['credentials' => $credentials, 'client' => clone $client]),
             $endpoints
         );
     },
@@ -48,10 +48,10 @@ return [
         ApiCredentials $credentials,
         ApiUrlCollection $endpoints
     ) {
-		$tokenHttpClient = clone $container->make('http.client');
+		$client = $container->make('http.client');
 
 		if ($credentials->hasCertificates()) {
-			$tokenHttpClient->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
+			$client->addSslCertificates(new \OWC\ZGW\Http\SslCertificatesStore(
 				$credentials->getPublicCertificate(),
 				$credentials->getPrivateCertificate(),
 				$credentials->getSupplierCertificate()
@@ -59,8 +59,8 @@ return [
 		}
 
         return new Clients\OpenWave\Client(
-            $container->make('http.client'),
-            $container->make(Clients\OpenWave\Authenticator::class, ['credentials' => $credentials, 'client' => $tokenHttpClient]),
+            $client,
+            $container->make(Clients\OpenWave\Authenticator::class, ['credentials' => $credentials, 'client' => clone $client]),
             $endpoints
         );
     },

--- a/src/Clients/OpenWave/Authenticator.php
+++ b/src/Clients/OpenWave/Authenticator.php
@@ -66,7 +66,7 @@ class Authenticator extends AbstractTokenAuthenticator
     {
         return new RequestOptions([
             'headers' => [
-                'Authorization' => 'Basic ' . base64_encode($this->credentials->getClientId() . ':' . $this->credentials->getClientSecret())
+                'Authorization' => 'Basic ' . base64_encode($this->credentials->getClientId() . ':' . $this->credentials->getClientSecret()),
             ],
         ]);
     }


### PR DESCRIPTION
Probleem

Sinds #34 (2.6.1) wordt 'http.client' in de container opgelost via $container->make() in plaats van $container->get(), zodat elk register zijn eigen WordPressRequestClient-instantie krijgt (en certificaten/hooks niet meer lekken tussen registers met dezelfde supplier).

De client-factories voor Mozart en OpenWave riepen $container->make('http.client') echter twee keer aan: één keer (gekloond) voor de client die de Authenticator gebruikt om het token op te halen, en een tweede keer voor de client die de daadwerkelijke resource-aanvragen doet. Met de oude singleton-aanpak leverden beide aanroepen toevallig dezelfde onderliggende instantie op, maar met make() zijn dit nu twee losse WordPressRequestClient-objecten met elk hun eigen instanceId.

De SSL-certificaten worden via globale WordPress-hooks (http_request_args, http_api_curl) toegepast, die zichzelf afschermen door het _owc_client_instance-request-header te vergelijken met het instanceId van de instantie waarop addSslCertificates() is aangeroepen. Omdat de tweede make('http.client')-aanroep een andere instantie (met een ander id) opleverde, werd het certificaat niet meegegeven aan die client — waardoor requests van die client zonder mTLS-certificaat werden verstuurd en de supplier deze afwees.

Oplossing

'http.client' nu maar één keer opvragen, de certificaten direct op die instantie zetten, en vervolgens een clone daarvan gebruiken voor de andere client. Omdat clone het instanceId overneemt, matchen beide clients (resource-client en token-client van de Authenticator) tegen dezelfde geregistreerde hook, en krijgen beide requests het certificaat correct toegepast.